### PR TITLE
Fix installation issue for Helm v3 and loadtester version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ cd gitops-istio
 Install Weave Flux and its Helm Operator by specifying your fork URL:
 
 ```bash
+# If you are using Helm v3, create the flux namespace first
+# kubectl create namespace flux
+
 ./scripts/flux-init.sh git@github.com:<YOUR-USERNAME>/gitops-istio
 ```
 

--- a/prod/backend/deployment.yaml
+++ b/prod/backend/deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: stefanprodan/podinfo:3.1.1
+        image: stefanprodan/podinfo:3.1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9898

--- a/prod/backend/deployment.yaml
+++ b/prod/backend/deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: stefanprodan/podinfo:3.1.0
+        image: stefanprodan/podinfo:3.1.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9898

--- a/prod/loadtest/deployment.yaml
+++ b/prod/loadtest/deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -17,44 +18,44 @@ spec:
         prometheus.io/scrape: "true"
     spec:
       containers:
-        - name: loadtester
-          image: weaveworks/flagger-loadtester:0.21.1
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: http
-              containerPort: 8080
-          command:
-            - ./loadtester
-            - -port=8080
-            - -log-level=info
-            - -timeout=1h
-          livenessProbe:
-            exec:
-              command:
-                - wget
-                - --quiet
-                - --tries=1
-                - --timeout=4
-                - --spider
-                - http://localhost:8080/healthz
-            timeoutSeconds: 5
-          readinessProbe:
-            exec:
-              command:
-                - wget
-                - --quiet
-                - --tries=1
-                - --timeout=4
-                - --spider
-                - http://localhost:8080/healthz
-            timeoutSeconds: 5
-          resources:
-            limits:
-              memory: "512Mi"
-              cpu: "1000m"
-            requests:
-              memory: "32Mi"
-              cpu: "10m"
-          securityContext:
-            readOnlyRootFilesystem: true
-            runAsUser: 10001
+      - name: loadtester
+        image: weaveworks/flagger-loadtester:0.12.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8080
+        command:
+        - ./loadtester
+        - -port=8080
+        - -log-level=info
+        - -timeout=1h
+        livenessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=4
+            - --spider
+            - http://localhost:8080/healthz
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - wget
+            - --quiet
+            - --tries=1
+            - --timeout=4
+            - --spider
+            - http://localhost:8080/healthz
+          timeoutSeconds: 5
+        resources:
+          limits:
+            memory: "512Mi"
+            cpu: "1000m"
+          requests:
+            memory: "32Mi"
+            cpu: "10m"
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 10001


### PR DESCRIPTION
- Fix Helm v3 `flux` namespace issue when initializing
- Change flagger-loadtester version from `0.21.1` to `0.12.1`