### PR TITLE
enforce istio webhook ordering

### DIFF
--- a/scripts/flux-init.sh
+++ b/scripts/flux-init.sh
@@ -83,7 +83,7 @@ until kubectl logs -n flux deployment/flux | grep event=refreshed
 do
   sleep 5
 done
-echo "istio sidecar injector ready"
+echo "Github deploy key ready"
 
 # wait until sidecar injector webhook is ready before enabled prod namespace on flux
 echo ">>> Waiting for istio sidecar injector to start"

--- a/scripts/flux-init.sh
+++ b/scripts/flux-init.sh
@@ -12,6 +12,8 @@ if [[ ! -x "$(command -v helm)" ]]; then
     exit 1
 fi
 
+REPO_GIT_INIT_PATHS="namespaces\,istio-system"
+REPO_GIT_ALL_PATHS="namespaces\,istio-system\,prod"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 REPO_URL=${1:-git@github.com:stefanprodan/gitops-istio}
 REPO_BRANCH=master
@@ -21,10 +23,12 @@ rm -rf ${TEMP} && mkdir ${TEMP}
 
 helm repo add fluxcd https://charts.fluxcd.io
 
-echo ">>> Installing Flux for ${REPO_URL}"
+echo ">>> Installing Flux for ${REPO_URL} only watching istio paths"
+kubectl create ns flux || true
 helm upgrade -i flux fluxcd/flux --wait \
 --set git.url=${REPO_URL} \
 --set git.branch=${REPO_BRANCH} \
+--set git.path=${REPO_GIT_INIT_PATHS} \
 --set git.pollInterval=1m \
 --set registry.pollInterval=1m \
 --namespace flux
@@ -63,7 +67,7 @@ configureRepositories:
 EOF
 
 echo ">>> Installing Helm Operator"
-kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/master/deploy/flux-helm-release-crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/master/deploy/crds.yaml
 helm upgrade -i helm-operator fluxcd/helm-operator --wait \
 --set git.ssh.secretName=flux-git-deploy \
 --set helm.versions=v3 \
@@ -72,3 +76,28 @@ helm upgrade -i helm-operator fluxcd/helm-operator --wait \
 
 echo '>>> GitHub deploy key'
 kubectl -n flux logs deployment/flux | grep identity.pub | cut -d '"' -f2
+
+# wait until flux is able to sync with repo
+echo ">>> Waiting on user to add above deploy key to Github repo"
+until kubectl logs -n flux deployment/flux | grep event=refreshed
+do
+  sleep 5
+done
+echo "istio sidecar injector ready"
+
+# wait until sidecar injector webhook is ready before enabled prod namespace on flux
+echo ">>> Waiting for istio sidecar injector to start"
+until kubectl get deploy -n istio-system -l app=sidecarInjectorWebhook | grep "1/1"
+do
+  sleep 5
+done
+echo "istio sidecar injector ready"
+
+echo ">>> Installing Flux for ${REPO_URL} watching all paths"
+helm upgrade -i flux fluxcd/flux --wait \
+--set git.url=${REPO_URL} \
+--set git.branch=${REPO_BRANCH} \
+--set git.path=${REPO_GIT_ALL_PATHS} \
+--set git.pollInterval=1m \
+--set registry.pollInterval=1m \
+--namespace flux


### PR DESCRIPTION
- Show friendly wait logs to guide user through installation process
- Install flux with only istio system
- Wait for sidecar injector webhook to be ready
- Upgrade flux with changed config to watch all paths including the prod path