### PR TITLE
revert to Istio to 1.6.8

### DIFF
--- a/istio/operator/manifests.yaml
+++ b/istio/operator/manifests.yaml
@@ -15,6 +15,53 @@ metadata:
   namespace: istio-operator
   name: istio-operator
 ---
+# Source: istio-operator/templates/crd-operator.yaml
+# SYNC WITH manifests/charts/base/files
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: istiooperators.install.istio.io
+spec:
+  group: install.istio.io
+  names:
+    kind: IstioOperator
+    plural: istiooperators
+    singular: istiooperator
+    shortNames:
+    - iop
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: 'Specification of the desired state of the istio control plane resource.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          type: object
+        status:
+          description: 'Status describes each of istio control plane component status at the current time.
+            0 means NONE, 1 means UPDATING, 2 means HEALTHY, 3 means ERROR, 4 means RECONCILING.
+            More info: https://github.com/istio/api/blob/master/operator/v1alpha1/istio.operator.v1alpha1.pb.html &
+            https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+---
 # Source: istio-operator/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -43,6 +90,12 @@ rules:
   - '*'
 - apiGroups:
   - networking.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.istio.io
   resources:
   - '*'
   verbs:
@@ -172,20 +225,10 @@ spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: docker.io/istio/operator:1.7.0
+          image: docker.io/istio/operator:1.6.8
           command:
           - operator
           - server
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            privileged: false
-            readOnlyRootFilesystem: true
-            runAsGroup: 1337
-            runAsUser: 1337
-            runAsNonRoot: true
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -196,16 +239,12 @@ spec:
               memory: 128Mi
           env:
             - name: WATCH_NAMESPACE
-              value: "istio-system"
+              value: istio-system
             - name: LEADER_ELECTION_NAMESPACE
-              value: "istio-operator"
+              value: istio-operator
             - name: POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "istio-operator"
-            - name: WAIT_FOR_RESOURCES_TIMEOUT
-              value: "300s"
-            - name: REVISION
-              value: ""
+              value: istio-operator


### PR DESCRIPTION
after istio update to 1.7.0 istio-operator fails with the following logs during flux-init

```2020-09-04T10:06:11.640335Z	info	ControlZ available at 127.0.0.1:9876
2020-09-04T10:06:11.640652Z	info	leader election cm: istio-operator-lock
2020-09-04T10:06:12.050103Z	info	Registering Components.
2020-09-04T10:06:12.050279Z	info	Adding controller for IstioOperator
2020-09-04T10:06:12.050526Z	info	Controller added
2020-09-04T10:06:12.050548Z	info	Starting the Cmd.
2020-09-04T10:06:12.050966Z	info	attempting to acquire leader lease  istio-operator/istio-operator-lock...
2020-09-04T10:06:29.463747Z	info	successfully acquired lease istio-operator/istio-operator-lock
2020-09-04T10:06:29.869514Z	fatal	Manager exited non-zero: no matches for kind "IstioOperator" in version "install.istio.io/v1alpha1"
```


I'm raising this more as an issue than a PR to fix.