### PR TITLE
Add Prometheus Istio addon

### DIFF
--- a/.github/actions/helm/entrypoint.sh
+++ b/.github/actions/helm/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -l
 
-VERSION=3.3.1
+VERSION=3.5.3
 curl -sL https://get.helm.sh/helm-v${VERSION}-linux-amd64.tar.gz | tar xz
 
 mkdir -p $GITHUB_WORKSPACE/bin

--- a/.github/workflows/update-istio.yaml
+++ b/.github/workflows/update-istio.yaml
@@ -25,12 +25,10 @@ jobs:
           ISTIO_VER=${ISTIO_DIR##./istio-}
 
           echo "Build manifests for ${ISTIO_VER} in dir ${ISTIO_DIR}"
-          helm template ${ISTIO_DIR}/manifests/charts/istio-operator/ \
-          --set hub=docker.io/istio \
-          --set tag=${ISTIO_VER} \
-          --set enableCRDTemplates=true \
-          --set operatorNamespace=istio-operator \
-          --set istioNamespace=istio-system  > ./istio/operator/manifests.yaml
+          helm template --include-crds \
+          ${ISTIO_DIR}/manifests/charts/istio-operator/ > ./istio/operator/manifests.yaml
+
+          cat ${ISTIO_DIR}/samples/addons/prometheus.yaml > ./istio/system/prometheus.yaml
 
           rm -rf ${ISTIO_DIR}
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 .DS_Store
 temp/
 bin/
+istio-*

--- a/istio/system/profile.yaml
+++ b/istio/system/profile.yaml
@@ -4,11 +4,4 @@ metadata:
   namespace: istio-system
   name: istio-default
 spec:
-  profile: default
-  components:
-    pilot:
-      k8s:
-        resources:
-          requests:
-            cpu: 10m
-            memory: 100Mi
+  profile: demo


### PR DESCRIPTION
Prepare for Istio 1.9:
- Add Prometheus manifests as its been removed from the Istio profile
- Use demo profile instead of default 
- Use Helm v3 to generate the Istio operator CRD and deployment