### PR TITLE
Update CI workflow for Istio v1.12.0

### DIFF
--- a/.github/workflows/update-istio.yaml
+++ b/.github/workflows/update-istio.yaml
@@ -29,6 +29,7 @@ jobs:
 
           echo "Build manifests for ${ISTIO_VER} in dir ${ISTIO_DIR}"
           helm template --include-crds \
+          --namespace istio-operator \
           ${ISTIO_DIR}/manifests/charts/istio-operator/ > ./istio/operator/manifests.yaml
 
           cat ${ISTIO_DIR}/samples/addons/prometheus.yaml > ./istio/system/prometheus.yaml
@@ -42,6 +43,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         if: steps.check.outputs.version
         with:
+          token: ${{ secrets.GH_ADMIN_TOKEN }}
           commit-message: Update Istio to ${{ steps.check.outputs.version }}
           title: Update Istio to ${{ steps.check.outputs.version }}
           body: |

--- a/istio/operator/manifests.yaml
+++ b/istio/operator/manifests.yaml
@@ -17,47 +17,38 @@ spec:
     plural: istiooperators
     singular: istiooperator
     shortNames:
-    - iop
-    - io
+      - iop
+      - io
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Istio control plane revision
-      jsonPath: .spec.revision
-      name: Revision
-      type: string
-    - description: IOP current state
-      jsonPath: .status.status
-      name: Status
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time
+    - additionalPrinterColumns:
+        - description: Istio control plane revision
+          jsonPath: .spec.revision
+          name: Revision
+          type: string
+        - description: IOP current state
+          jsonPath: .status.status
+          name: Status
+          type: string
+        - description: 'CreationTimestamp is a timestamp representing the server time
         when this object was created. It is not guaranteed to be set in happens-before
         order across separate operations. Clients may not set this value. It is represented
         in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
         lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    subresources:
-      status: {}
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    served: true
-    storage: true
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: true
 ---
 
----
-# Source: istio-operator/templates/namespace.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-operator
-  labels:
-    istio-operator-managed: Reconcile
-    istio-injection: disabled
 ---
 # Source: istio-operator/templates/service_account.yaml
 apiVersion: v1
@@ -73,114 +64,115 @@ metadata:
   creationTimestamp: null
   name: istio-operator
 rules:
-# istio groups
-- apiGroups:
-  - authentication.istio.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - config.istio.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - install.istio.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - networking.istio.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - security.istio.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-# k8s groups
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  - validatingwebhookconfigurations
-  verbs:
-  - '*'
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions.apiextensions.k8s.io
-  - customresourcedefinitions
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  - extensions
-  resources:
-  - daemonsets
-  - deployments
-  - deployments/finalizers
-  - replicasets
-  verbs:
-  - '*'
-- apiGroups:
-  - autoscaling
-  resources:
-  - horizontalpodautoscalers
-  verbs:
-  - '*'
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
-  - update
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - '*'
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  - clusterroles
-  - roles
-  - rolebindings
-  verbs:
-  - '*'
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - create
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - endpoints
-  - events
-  - namespaces
-  - pods
-  - pods/proxy
-  - persistentvolumeclaims
-  - secrets
-  - services
-  - serviceaccounts
-  verbs:
-  - '*'
+  # istio groups
+  - apiGroups:
+      - authentication.istio.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - config.istio.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - install.istio.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - security.istio.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  # k8s groups
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions.apiextensions.k8s.io
+      - customresourcedefinitions
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+      - deployments/finalizers
+      - replicasets
+    verbs:
+      - '*'
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - '*'
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - '*'
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - roles
+      - rolebindings
+    verbs:
+      - '*'
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - namespaces
+      - pods
+      - pods/proxy
+      - pods/portforward
+      - persistentvolumeclaims
+      - secrets
+      - services
+      - serviceaccounts
+    verbs:
+      - '*'
 ---
 # Source: istio-operator/templates/clusterrole_binding.yaml
 kind: ClusterRoleBinding
@@ -188,9 +180,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: istio-operator
 subjects:
-- kind: ServiceAccount
-  name: istio-operator
-  namespace: istio-operator
+  - kind: ServiceAccount
+    name: istio-operator
+    namespace: istio-operator
 roleRef:
   kind: ClusterRole
   name: istio-operator
@@ -206,10 +198,10 @@ metadata:
   name: istio-operator
 spec:
   ports:
-  - name: http-metrics
-    port: 8383
-    targetPort: 8383
-    protocol: TCP
+    - name: http-metrics
+      port: 8383
+      targetPort: 8383
+      protocol: TCP
   selector:
     name: istio-operator
 ---
@@ -232,15 +224,15 @@ spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: docker.io/istio/operator:1.11.4
+          image: docker.io/istio/operator:1.12.0
           command:
-          - operator
-          - server
+            - operator
+            - server
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-              - ALL
+                - ALL
             privileged: false
             readOnlyRootFilesystem: true
             runAsGroup: 1337

--- a/istio/operator/namespace.yaml
+++ b/istio/operator/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-operator
+  labels:
+    istio-operator-managed: Reconcile
+    istio-injection: disabled

--- a/istio/system/prometheus.yaml
+++ b/istio/system/prometheus.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: prometheus
-    chart: prometheus-14.3.0
+    chart: prometheus-14.6.1
     heritage: Helm
   name: prometheus
   namespace: istio-system
@@ -22,7 +22,7 @@ metadata:
     component: "server"
     app: prometheus
     release: prometheus
-    chart: prometheus-14.3.0
+    chart: prometheus-14.6.1
     heritage: Helm
   name: prometheus
   namespace: istio-system
@@ -250,7 +250,7 @@ data:
         - __meta_kubernetes_pod_name
         target_label: kubernetes_pod_name
       - action: drop
-        regex: Pending|Succeeded|Failed
+        regex: Pending|Succeeded|Failed|Completed
         source_labels:
         - __meta_kubernetes_pod_phase
     - job_name: kubernetes-pods-slow
@@ -289,7 +289,7 @@ data:
         - __meta_kubernetes_pod_name
         target_label: kubernetes_pod_name
       - action: drop
-        regex: Pending|Succeeded|Failed
+        regex: Pending|Succeeded|Failed|Completed
         source_labels:
         - __meta_kubernetes_pod_phase
       scrape_interval: 5m
@@ -307,7 +307,7 @@ metadata:
     component: "server"
     app: prometheus
     release: prometheus
-    chart: prometheus-14.3.0
+    chart: prometheus-14.6.1
     heritage: Helm
   name: prometheus
 rules:
@@ -349,7 +349,7 @@ metadata:
     component: "server"
     app: prometheus
     release: prometheus
-    chart: prometheus-14.3.0
+    chart: prometheus-14.6.1
     heritage: Helm
   name: prometheus
 subjects:
@@ -369,7 +369,7 @@ metadata:
     component: "server"
     app: prometheus
     release: prometheus
-    chart: prometheus-14.3.0
+    chart: prometheus-14.6.1
     heritage: Helm
   name: prometheus
   namespace: istio-system
@@ -394,7 +394,7 @@ metadata:
     component: "server"
     app: prometheus
     release: prometheus
-    chart: prometheus-14.3.0
+    chart: prometheus-14.6.1
     heritage: Helm
   name: prometheus
   namespace: istio-system
@@ -407,16 +407,16 @@ spec:
   replicas: 1
   template:
     metadata:
-      annotations:
-        
-        sidecar.istio.io/inject: "false"
       labels:
         component: "server"
         app: prometheus
         release: prometheus
-        chart: prometheus-14.3.0
+        chart: prometheus-14.6.1
         heritage: Helm
+
+        sidecar.istio.io/inject: "false"
     spec:
+      enableServiceLinks: true
       serviceAccountName: prometheus
       containers:
         - name: prometheus-server-configmap-reload


### PR DESCRIPTION
The Istio 1.12 chart comes with breaking changes, the namespace was removed the Istio operator chart. This PR adds back the namespace definition and sets the namespace to `istio-operator` in the upgrade workflow.

Supersedes: #57 
Ref: https://github.com/istio/istio/issues/36207