### PR TITLE
Bring all Istio Components up to 1.18.5, update hpa version

### DIFF
--- a/apps/backend/deployment.patch.yaml
+++ b/apps/backend/deployment.patch.yaml
@@ -95,7 +95,7 @@
         value: cluster.local
       - name: ISTIO_PROMETHEUS_ANNOTATIONS
         value: '{"scrape":"true","path":"","port":""}'
-    image: docker.io/istio/proxyv2:1.13.3
+    image: docker.io/istio/proxyv2:1.18.5
     name: istio-proxy
     ports:
       - containerPort: 15090
@@ -158,7 +158,7 @@
         - '*'
         - -d
         - 15090,15021,15020
-      image: docker.io/istio/proxyv2:1.13.3
+      image: docker.io/istio/proxyv2:1.18.5
       name: istio-init
       resources:
         limits:

--- a/apps/backend/hpa.yaml
+++ b/apps/backend/hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: backend

--- a/apps/frontend/deployment.patch.yaml
+++ b/apps/frontend/deployment.patch.yaml
@@ -95,7 +95,7 @@
         value: cluster.local
       - name: ISTIO_PROMETHEUS_ANNOTATIONS
         value: '{"scrape":"true","path":"","port":""}'
-    image: docker.io/istio/proxyv2:1.13.3
+    image: docker.io/istio/proxyv2:1.18.5
     name: istio-proxy
     ports:
       - containerPort: 15090
@@ -158,7 +158,7 @@
         - '*'
         - -d
         - 15090,15021,15020
-      image: docker.io/istio/proxyv2:1.13.3
+      image: docker.io/istio/proxyv2:1.18.5
       name: istio-init
       resources:
         limits:

--- a/apps/frontend/hpa.yaml
+++ b/apps/frontend/hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: frontend

--- a/apps/loadtest/deployment.patch.yaml
+++ b/apps/loadtest/deployment.patch.yaml
@@ -98,7 +98,7 @@
         value: cluster.local
       - name: ISTIO_PROMETHEUS_ANNOTATIONS
         value: '{"scrape":"true","path":"","port":""}'
-    image: docker.io/istio/proxyv2:1.13.3
+    image: docker.io/istio/proxyv2:1.18.5
     name: istio-proxy
     ports:
       - containerPort: 15090
@@ -161,7 +161,7 @@
         - '*'
         - -d
         - 15090,15021,15020
-      image: docker.io/istio/proxyv2:1.13.3
+      image: docker.io/istio/proxyv2:1.18.5
       name: istio-init
       resources:
         limits:

--- a/clusters/my-cluster/istio-version.yaml
+++ b/clusters/my-cluster/istio-version.yaml
@@ -6,4 +6,4 @@ metadata:
   annotations:
     kustomize.toolkit.fluxcd.io/ssa: merge
 data:
-  version: 1.13.3
+  version: 1.18.5


### PR DESCRIPTION
upgrades got stuck on 1.13.  That has been fixed, but you can't upgrade from 1.13 to 1.19 like it's trying to do.